### PR TITLE
fix: add ui5.yaml to npm package content

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,20 @@ Add the `fontawesome.icons.lib` library dependency to your `manifest.json` and f
 }
 ```
 
-### Method 1: Using NPM Package with UI5 middleware (Recommended) 
+### Method 1: Using NPM Package (Recommended)
 
 Install Dependencies
 
 ```bash
-npm install ui5-fontawesome-lib ui5-middleware-servestatic --save-dev
+npm i ui5-fontawesome-lib
+```
+
+That should be it. The UI5 tooling will recognize the UI5 dependency (verifiable via UI5 CLI command `UI5 tree`) and take care of loading it for you.
+
+#### with UI5 middleware (alternative recommendation)
+
+```bash
+npm i ui5-fontawesome-lib && npm i -D ui5-middleware-servestatic
 ```
 
 Add the following configuration to your `ui5.yaml`:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dist/**/*",
     "src/**/*",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "ui5.yaml"
   ],
   "scripts": {
     "build": "npm run build:icons && ui5 build --clean-dest",

--- a/ui5.yaml
+++ b/ui5.yaml
@@ -1,4 +1,4 @@
-specVersion: "1.0"
+specVersion: "4.0"
 metadata:
   name: fontawesome.icons.lib
 type: library


### PR DESCRIPTION
Hi Mario,

I took the liberty to quickly add these:

- bumped `ui5.yaml` to current specVer
- adjusted README to give native UI5 tooling consumption precedence
- adjusted README npm installs to save the lib as actual dep and the middleware as devDep
- added `ui5.yaml` to files property of `package.json`

--- 

Tested the "native" consumption via tooling with a locally created TS application. Added the library as npm dependency and patched the addition of the `ui5.yaml` manually within the `node_modules` folder. No additional tooling aside from `ui5-middleware-livereload` and `ui5-tooling-transpile-(middleware|task)`.

Also tested self-contained build using
```yaml
builder:
  settings:
    includeDependency:
      - "fontawesome.icons.lib"
```

Hth., Marco 